### PR TITLE
Update "Circuit Power Measurement Combinator" for Factorio 1.1.

### DIFF
--- a/factorio/Circuit_Power_Measurement_Combinator/control.lua
+++ b/factorio/Circuit_Power_Measurement_Combinator/control.lua
@@ -112,7 +112,7 @@ local function update_meter_signal(meter)
 
 	-- Scan existing signals for slots to replace or fill-in
 	local ps, ps_stat, ps_free, ps_last = {}, {}, {}, meter.params_last or {}
-	for n, p in ipairs(ecc.parameters.parameters) do
+	for n, p in ipairs(ecc.parameters) do
 		if not p.signal.name then table.insert(ps_free, {n, p.index})
 		else
 			k = ('%s.%s'):format(p.signal.type, p.signal.name)
@@ -144,7 +144,7 @@ local function update_meter_signal(meter)
 		else break end
 	end
 
-	ecc.parameters = {parameters=ps}
+	ecc.parameters = ps
 end
 
 

--- a/factorio/Circuit_Power_Measurement_Combinator/info.json
+++ b/factorio/Circuit_Power_Measurement_Combinator/info.json
@@ -1,7 +1,7 @@
 {
 	"name": "Circuit_Power_Measurement_Combinator",
 	"version": "0.0.7",
-	"factorio_version": "1.0",
+	"factorio_version": "1.1",
 	"dependencies": ["base >= 0.18.0", "? SchallCircuitGroup"],
 	"title": "Circuit Power Measurement Combinator",
 	"author": "mk-fg",


### PR DESCRIPTION
https://forums.factorio.com/viewtopic.php?f=34&t=91606
> Changed 'control_behavior.parameters.parameters' to just 'control_behavior.parameters' for LuaDeciderCombinatorControlBehavior, LuaConstantCombinatorControlBehavior, and LuaArithmeticCombinatorControlBehavior.

I made two small changes in `control.lua` to match, and now it works for me in Factorio 1.1.